### PR TITLE
Prevent inefficient autoloader of client projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,11 @@
     },
     "autoload": {
         "psr-4": {
-            "": "src",
+            "HL7\\FHIR\\": "src/HL7/FHIR"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "FHIR\\Tests\\": "tests"
         }
     }


### PR DESCRIPTION
This fixes the following issues:

- Users of this library would get `FHIR\Tests\` in their autoloader which wasn't relevant and costs a small amount of performance
- Users of this library would get `""` (any namespace that isn't resolved yet) mapped to `src/` of this specific library, which could potentially cost a lot of performance depending on the client code